### PR TITLE
features/34-GamePage-ViewModelNWin

### DIFF
--- a/NumberBomb/NumberBomb/GamePage.xaml
+++ b/NumberBomb/NumberBomb/GamePage.xaml
@@ -2,8 +2,7 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
-             x:Class="NumberBomb.GamePage"
-             BackgroundColor="#EFEFEF">
+             x:Class="NumberBomb.GamePage">
     <NavigationPage.TitleView>
          <StackLayout Orientation="Horizontal">
             <Label  x:Name="TitleLabel"
@@ -37,7 +36,7 @@
             </Image>
          </StackLayout>
     </NavigationPage.TitleView>
-    <ContentPage.Content>
+    <ContentPage.Content>       
         <StackLayout>
             <Label 
                    FontSize="18"
@@ -57,7 +56,8 @@
                         HorizontalTextAlignment="Center"
                         FontSize="18"
                         Padding="26,63,17,63"/>
-            <Entry x:Name="GuessEntry"
+            <Entry 
+                       Text="{Binding GuessEntry}"
                        Keyboard="Numeric"
                        WidthRequest="80"
                        Margin="0,0,0,17"
@@ -84,7 +84,7 @@
                             HeightRequest="66"
                             FontFamily="PatrickFont"
                             CornerRadius="18"
-                            Command = "{Binding ButtonCommand}"/>
+                            Command = "{Binding CheckCommand}"/>
             </yummy:PancakeView>
             </StackLayout>    
     </ContentPage.Content>

--- a/NumberBomb/NumberBomb/GamePage.xaml.cs
+++ b/NumberBomb/NumberBomb/GamePage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using NumberBomb.ViewModels;
 using Xamarin.Forms;
 
 namespace NumberBomb
@@ -10,6 +10,8 @@ namespace NumberBomb
         public GamePage()
         {
             InitializeComponent();
+
+            BindingContext = new GamePageViewModel();
 
             if (Device.RuntimePlatform.Equals("Android"))
             {

--- a/NumberBomb/NumberBomb/NumberBomb.csproj
+++ b/NumberBomb/NumberBomb/NumberBomb.csproj
@@ -41,5 +41,8 @@
     <Compile Update="GamerTagPage.xaml.cs">
       <DependentUpon>GamerTagPage.xaml</DependentUpon>
     </Compile>
+    <Compile Update="WinPage.xaml.cs">
+      <DependentUpon>WinPage.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/NumberBomb/NumberBomb/ViewModels/GamePageViewModel.cs
+++ b/NumberBomb/NumberBomb/ViewModels/GamePageViewModel.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace NumberBomb.ViewModels
+{
+    public class GamePageViewModel : INotifyPropertyChanged
+    {
+        public string _number;
+        public int RandomNumber;
+        public int GuessedValue;
+        public event PropertyChangedEventHandler PropertyChanged;
+        public ICommand CheckCommand { get; set; }
+
+        public string GuessEntry
+        {
+            get => _number;
+            set
+            {
+                _number = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GuessEntry)));
+            }
+        }
+
+        public GamePageViewModel()
+        {
+            Random randomNumberGenrator = new Random();
+            RandomNumber = randomNumberGenrator.Next(100) + 1;
+            if (GuessEntry == null)
+            {
+                GuessEntry = "0";
+            }
+            CheckCommand = new Command(CheckCommandExecute);
+        }
+
+        private void CheckCommandExecute(object obj)
+        {
+            GuessedValue = Convert.ToInt32(GuessEntry);
+            if (RandomNumber == GuessedValue)
+            {
+                App.Current.MainPage.Navigation.PushAsync(new WinPage());
+            }
+        }
+    }
+}

--- a/NumberBomb/NumberBomb/WinPage.xaml
+++ b/NumberBomb/NumberBomb/WinPage.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="NumberBomb.WinPage">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="Congratulations, you won" HorizontalOptions="Center" VerticalOptions="Center" FontSize="18"/>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/NumberBomb/NumberBomb/WinPage.xaml.cs
+++ b/NumberBomb/NumberBomb/WinPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace NumberBomb
+{
+    public partial class WinPage : ContentPage
+    {
+        public WinPage()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
* Made the entry accept only numbers
* Created a GamePageViewModel binded to the Page
* The ViewModel contains the RandomNumber int property that contains a random number from 1-100 that will be stored for the entire game session
* Created a GuessedValue int property that is binded to the EditText field, so that it holds the value of the number guessed
When the user presses Submit, create a Command that checks whether the RandomNumber==GuessedValue. If yes, then go to a blank WinPage

**Testing**
----------------------------------

* iOS > HomePage > Click Start > enter a number > submit > WinPage
* Android >  HomePage > Click Start > enter a number > submit > WinPage