### PR TITLE
features/43-ChangeUserPage

### DIFF
--- a/NumberBomb/NumberBomb/ChangeUserPage.xaml
+++ b/NumberBomb/NumberBomb/ChangeUserPage.xaml
@@ -2,9 +2,76 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="NumberBomb.ChangeUserPage">
+     <NavigationPage.TitleView>
+         <StackLayout Orientation="Horizontal">
+            <Label  x:Name="TitleLabel"
+                    FontSize="25"
+                    TextColor="Black"
+                    VerticalOptions="CenterAndExpand"
+                    HorizontalOptions="Center"
+                    FontFamily="PatrickFont">
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="Number"/>
+                        <Span Text="BOMB" TextColor="Red"/>
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>           
+         </StackLayout>
+    </NavigationPage.TitleView>
     <ContentPage.Content>
-        <StackLayout>
-            <Label Text="ChangeUserPage" HorizontalOptions="Center" VerticalOptions="Center"/>
-        </StackLayout>
+        <StackLayout VerticalOptions="FillAndExpand">
+            <StackLayout Padding="40,39,40,0">
+                <Label   FontSize="36"
+                         TextColor="Black"
+                         HorizontalTextAlignment="Center"
+                         FontFamily="PatrickFont">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="Number"/>
+                            <Span Text="BOMB" TextColor="Red"/>
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>
+                <Label Text="Guess the number to diffuse the bomb"
+                       TextColor="Black"
+                       Opacity=".5"
+                       FontSize="12"
+                       FontFamily="PatrickFont"
+                       HorizontalTextAlignment="Center"/>
+                <Label Text="Switch your gamer tag"
+                       FontFamily="PatrickFont"
+                       Padding="0,70,0,14"
+                       FontSize="20"
+                       TextColor="Black"
+                       HorizontalTextAlignment="Center"/>
+                <Entry x:Name="NameEntry"
+                       Text="{Binding ChangeName}"
+                       WidthRequest="200"
+                       HorizontalOptions="Center"/>
+                <Button Text="Save" 
+                        BackgroundColor="Black"
+                        TextColor="White"
+                        FontSize="18"
+                        WidthRequest="129"
+                        HeightRequest="46"
+                        Padding="0,10, 0, 10"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"
+                        FontFamily="PatrickFont"
+                        Margin="0,64,0,0"
+                        CornerRadius="23"
+                        Command = "{Binding SaveButtonCommand}"/>
+            </StackLayout>
+            <Image 
+                        Margin="5,0,0,14"
+                        Source="bomb.png"
+                        HorizontalOptions="Start"
+                        VerticalOptions="EndAndExpand"
+                        WidthRequest="138"
+                        HeightRequest="138"/>
+        
+    </StackLayout>
     </ContentPage.Content>
 </ContentPage>
+

--- a/NumberBomb/NumberBomb/ChangeUserPage.xaml.cs
+++ b/NumberBomb/NumberBomb/ChangeUserPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using NumberBomb.ViewModels;
 using Xamarin.Forms;
 
 namespace NumberBomb
@@ -10,6 +10,17 @@ namespace NumberBomb
         public ChangeUserPage()
         {
             InitializeComponent();
+
+            BindingContext = new ChangeUserViewModel();
+
+            if (Device.RuntimePlatform.Equals("Android"))
+            {
+                TitleLabel.HorizontalOptions = LayoutOptions.StartAndExpand;
+            }
+            else if (Device.RuntimePlatform.Equals("iOS"))
+            {
+                TitleLabel.HorizontalOptions = LayoutOptions.CenterAndExpand;
+            }
         }
     }
 }

--- a/NumberBomb/NumberBomb/ViewModels/ChangeUserViewModel.cs
+++ b/NumberBomb/NumberBomb/ViewModels/ChangeUserViewModel.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Input;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+
+namespace NumberBomb.ViewModels
+{
+    public class ChangeUserViewModel : INotifyPropertyChanged
+    {
+        public string _newName;
+        public ICommand SaveButtonCommand { get; set; }
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public string ChangeName
+        {
+            get
+            {
+                return _newName;
+            }
+            set
+            {
+                _newName = value;
+                if (PropertyChanged != null)
+                {
+                    PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(ChangeName)));
+                }
+            }
+        }
+
+        public ChangeUserViewModel()
+        {
+            ChangeName = Preferences.Get("NameTag", string.Empty);
+            SaveButtonCommand = new Command(SaveCommandExecute);
+        }
+
+        private void SaveCommandExecute(object obj)
+        {
+            if (!String.IsNullOrEmpty(ChangeName))
+            {
+                Preferences.Set("NameTag", ChangeName);
+                Application.Current.MainPage.Navigation.PopAsync();
+            }
+        }
+    }
+}

--- a/NumberBomb/NumberBomb/ViewModels/GamerTagViewModel.cs
+++ b/NumberBomb/NumberBomb/ViewModels/GamerTagViewModel.cs
@@ -34,8 +34,11 @@ namespace NumberBomb.ViewModels
 
         private void ButtonCommandExecute(object obj)
         {
-            Preferences.Set("NameTag", GamerTag);
-            App.Current.MainPage = new NavigationPage(new HomePage());
+            if (!String.IsNullOrEmpty(GamerTag))
+            {
+                Preferences.Set("NameTag", GamerTag);
+                App.Current.MainPage = new NavigationPage(new HomePage());
+            }
         }
     }
 }


### PR DESCRIPTION
* Created a UI and ViewModel for ChangeUserPage
* When the user presses Save button, the ChangeUserPage pops
* The entry shouldn't be null nor empty in order to pop the page
* Changed the initial gamertag page as well, to not leave the page unless the entry is not blank nor null

**Testing**
------------------------------------------

*  iOS > GamerTag > Click Enter > Entry is empty > Nothing
   happens
*  iOS > GamerTag > Enter a name > Click Enter > HomePage
*  Android > GamerTag > Click Enter > Entry is empty >
   Nothing happens
* Android > GamerTag > Enter a name > Click Enter >
  HomePage

* iOS > HomePage > Click User Icon > Click Save > Entry is
    empty > Nothing happens
* iOS > HomePage > Click User Icon >  Enter a name > Click
   Save > GamerTag is updated
* Android > HomePage > Click User Icon > Click Save >
    Entry is empty > Nothing happens
* Android > HomePage > Click User Icon >  Enter a name >
   Click Save > GamerTag is updated